### PR TITLE
Feature generics

### DIFF
--- a/src/DiskQueue.Tests/GenericQueueTests.cs
+++ b/src/DiskQueue.Tests/GenericQueueTests.cs
@@ -1,0 +1,119 @@
+﻿using System;
+using NUnit.Framework;
+
+namespace DiskQueue.Tests
+{
+    [TestFixture, SingleThreaded]
+    public class GenericQueueTests
+    {
+        [Test]
+        public void Round_trip_value_type()
+        {
+            using var queue = new PersistentQueue<int>("./GenericQueueTests1");
+            using var session = queue.OpenSession();
+
+            session.Enqueue(7);
+            session.Flush();
+            var testNumber = session.Dequeue();
+            session.Flush();
+            Assert.AreEqual(7, testNumber);
+        }
+
+        [TestCase("Test")]
+        [TestCase("")]
+        [TestCase(" Leading Spaces")]
+        [TestCase("Trailing Spaces   ")]
+        public void Round_trip_string_type(string valueToTest)
+        {
+            // Use different queue for each test case so that we don't get errors when running tests concurrently.
+            using var queue = new PersistentQueue<string>($"./GenericQueueTests3{valueToTest.Trim()}");
+            using var session = queue.OpenSession();
+
+            session.Enqueue(valueToTest);
+            session.Flush();
+            var returnValue = session.Dequeue();
+            session.Flush();
+            Assert.AreEqual(valueToTest, returnValue);
+        }
+
+        [Test]
+        public void Round_trip_complex_type()
+        {
+            using var queue = new PersistentQueue<TestClass>("./GenericQueueTests2");
+            using var session = queue.OpenSession();
+
+            var testObject = new TestClass(7, "TestString", null);
+            session.Enqueue(testObject);
+            session.Flush();
+            var testObject2 = session.Dequeue();
+            session.Flush();
+            Assert.IsNotNull(testObject2);
+            Assert.AreEqual(testObject,testObject2);
+
+            testObject = new TestClass(7, "TestString", -5);
+            session.Enqueue(testObject);
+            session.Flush();
+            testObject2 = session.Dequeue();
+            session.Flush();
+            Assert.IsNotNull(testObject2);
+            Assert.AreEqual(testObject, testObject2);
+        }
+    }
+
+    /// <summary>
+    /// Test class for tests on <see cref="PersistentQueue{T}"/>
+    /// </summary>
+    [Serializable]
+    public class TestClass : IEquatable<TestClass>
+    {
+        public TestClass(int integerValue, string stringValue, int? nullableIntegerValue)
+        {
+            IntegerValue = integerValue;
+            StringValue = stringValue;
+            NullableIntegerValue = nullableIntegerValue;
+        }
+
+        public int IntegerValue { get; }
+        public string StringValue { get; }
+        public int? NullableIntegerValue { get; }
+
+        public bool Equals(TestClass? other)
+        {
+            if (ReferenceEquals(null, other)) return false;
+            if (ReferenceEquals(this, other)) return true;
+            return IntegerValue == other.IntegerValue && StringValue == other.StringValue && NullableIntegerValue == other.NullableIntegerValue;
+        }
+
+        public override bool Equals(object? obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != this.GetType()) return false;
+            return Equals((TestClass)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(IntegerValue, StringValue, NullableIntegerValue);
+        }
+
+        public static bool operator ==(TestClass left, TestClass right)
+        {
+            return Equals(left, right);
+        }
+
+        public static bool operator !=(TestClass left, TestClass right)
+        {
+            return !Equals(left, right);
+        }
+
+        /// <summary>
+        /// Override ToString so that the contents can easily be inspected in the debugger.
+        /// </summary>
+        /// <returns></returns>
+        public override string ToString()
+        {
+            return $"{IntegerValue}|{StringValue}|{NullableIntegerValue}";
+        }
+    }
+}

--- a/src/DiskQueue/DiskQueue.csproj
+++ b/src/DiskQueue/DiskQueue.csproj
@@ -16,12 +16,13 @@
     <DocumentationFile>bin\Debug\DiskQueue.xml</DocumentationFile>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <Optimize>true</Optimize>
+    <Optimize>false</Optimize>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <Optimize>true</Optimize>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/DiskQueue/IPersistentQueueT.cs
+++ b/src/DiskQueue/IPersistentQueueT.cs
@@ -2,12 +2,8 @@
 
 namespace DiskQueue
 {
-    /// <summary>
-    /// A queue tied to a specific persistent storage backing.
-    /// Enqueue and dequeue operations happen within sessions.
-    /// <example>using (var session = q.OpenSession()) {...}</example>
-    /// Queue should be disposed after use. This will NOT destroy the backing storage.
-    /// </summary>
+
+    /// <inheritdoc />
     public interface IPersistentQueue<T> : IPersistentQueue
     {
         /// <summary>

--- a/src/DiskQueue/IPersistentQueueT.cs
+++ b/src/DiskQueue/IPersistentQueueT.cs
@@ -1,0 +1,18 @@
+﻿using System;
+
+namespace DiskQueue
+{
+    /// <summary>
+    /// A queue tied to a specific persistent storage backing.
+    /// Enqueue and dequeue operations happen within sessions.
+    /// <example>using (var session = q.OpenSession()) {...}</example>
+    /// Queue should be disposed after use. This will NOT destroy the backing storage.
+    /// </summary>
+    public interface IPersistentQueue<T> : IPersistentQueue
+    {
+        /// <summary>
+        /// Open an read/write session
+        /// </summary>
+        new IPersistentQueueSession<T> OpenSession();
+    }
+}

--- a/src/DiskQueue/Implementation/DefaultSerializationStrategy.cs
+++ b/src/DiskQueue/Implementation/DefaultSerializationStrategy.cs
@@ -1,0 +1,43 @@
+﻿using System.IO;
+using System.Runtime.Serialization.Formatters.Binary;
+
+namespace DiskQueue.Implementation
+{
+    /// <summary>
+    /// This class performs basic binary serialization from objects of Type T to byte arrays suitable for use in DiskQueue sessions.
+    /// </summary>
+    /// <remarks>
+    /// You are free to implement your own <see cref="ISerializationStrategy{T}"/> and inject it into <see cref="PersistentQueue{T}"/>.
+    /// </remarks>
+    /// <typeparam name="T"></typeparam>
+    internal class DefaultSerializationStrategy<T> : ISerializationStrategy<T>
+    {
+        /// <inheritdoc />
+        public T? Deserialize(byte[]? bytes)
+        {
+            if (bytes == null)
+            {
+                return default;
+            }
+
+            BinaryFormatter bf = new();
+            using MemoryStream ms = new(bytes);
+            object obj = bf.Deserialize(ms);
+            return (T)obj;
+        }
+
+        /// <inheritdoc />
+        public byte[]? Serialize(T? obj)
+        {
+            if (obj == null)
+            {
+                return null;
+            }
+
+            BinaryFormatter bf = new();
+            using MemoryStream ms = new();
+            bf.Serialize(ms, obj);
+            return ms.ToArray();
+        }
+    }
+}

--- a/src/DiskQueue/Implementation/PersistentQueueImpl.cs
+++ b/src/DiskQueue/Implementation/PersistentQueueImpl.cs
@@ -753,7 +753,7 @@ namespace DiskQueue.Implementation
 			return transactionBuffer;
 		}
 
-		private IFileStream CreateWriter()
+		protected IFileStream CreateWriter()
 		{
 			var dataFilePath = GetDataPath(CurrentFileNumber);
 			return _file.OpenWriteStream(dataFilePath);

--- a/src/DiskQueue/Implementation/PersistentQueueImplT.cs
+++ b/src/DiskQueue/Implementation/PersistentQueueImplT.cs
@@ -1,10 +1,6 @@
-﻿using DiskQueue.PublicInterfaces;
-using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace DiskQueue.Implementation
+﻿namespace DiskQueue.Implementation
 {
+    /// <inheritdoc cref="IPersistentQueueImpl{T}"/>
     internal class PersistentQueueImpl<T> : PersistentQueueImpl, IPersistentQueueImpl<T>
     {
         public PersistentQueueImpl(string path) : base(path) { }

--- a/src/DiskQueue/Implementation/PersistentQueueImplT.cs
+++ b/src/DiskQueue/Implementation/PersistentQueueImplT.cs
@@ -1,0 +1,18 @@
+﻿using DiskQueue.PublicInterfaces;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace DiskQueue.Implementation
+{
+    internal class PersistentQueueImpl<T> : PersistentQueueImpl, IPersistentQueueImpl<T>
+    {
+        public PersistentQueueImpl(string path) : base(path) { }
+        public PersistentQueueImpl(string path, int maxFileSize, bool throwOnConflict) : base(path, maxFileSize, throwOnConflict) { }
+
+        public new IPersistentQueueSession<T> OpenSession()
+        {
+            return new PersistentQueueSession<T>(this, CreateWriter(), SuggestedWriteBuffer, FileTimeoutMilliseconds);
+        }
+    }
+}

--- a/src/DiskQueue/Implementation/PersistentQueueSession.cs
+++ b/src/DiskQueue/Implementation/PersistentQueueSession.cs
@@ -11,7 +11,7 @@ namespace DiskQueue.Implementation
 	/// <para>You should use <see cref="IPersistentQueue.OpenSession"/> to get a session.</para>
 	/// <example>using (var q = PersistentQueue.WaitFor("myQueue")) using (var session = q.OpenSession()) { ... }</example>
 	/// </summary>
-	public sealed class PersistentQueueSession : IPersistentQueueSession
+	public class PersistentQueueSession : IPersistentQueueSession
 	{
 		private readonly List<Operation> _operations = new();
 		private readonly List<Exception> _pendingWritesFailures = new();

--- a/src/DiskQueue/Implementation/PersistentQueueSessionT.cs
+++ b/src/DiskQueue/Implementation/PersistentQueueSessionT.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace DiskQueue.Implementation
+{
+    internal class PersistentQueueSession<T> : PersistentQueueSession, IPersistentQueueSession<T>
+    {
+        public PersistentQueueSession(IPersistentQueueImpl queue, IFileStream currentStream, int writeBufferSize, int timeoutLimit) : base(queue, currentStream, writeBufferSize, timeoutLimit)
+        {
+        }
+
+        public new T? Dequeue()
+        {
+            throw new NotImplementedException();
+        }
+        public void Enqueue(T data)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/DiskQueue/Implementation/PersistentQueueSessionT.cs
+++ b/src/DiskQueue/Implementation/PersistentQueueSessionT.cs
@@ -1,22 +1,37 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace DiskQueue.Implementation
+﻿namespace DiskQueue.Implementation
 {
-    internal class PersistentQueueSession<T> : PersistentQueueSession, IPersistentQueueSession<T>
+    /// <inheritdoc cref="IPersistentQueueSession{T}"/>
+    public class PersistentQueueSession<T> : PersistentQueueSession, IPersistentQueueSession<T>
     {
-        public PersistentQueueSession(IPersistentQueueImpl queue, IFileStream currentStream, int writeBufferSize, int timeoutLimit) : base(queue, currentStream, writeBufferSize, timeoutLimit)
+        /// <summary>
+        /// This class performs the serialization of the object to be queued into a byte array suitable for queueing.
+        /// It defaults to <see cref="DefaultSerializationStrategy{T}"/>, but you are free to implement your own and inject it in.
+        /// </summary>
+        public ISerializationStrategy<T> SerializationStrategy { get; set; } = new DefaultSerializationStrategy<T>();
+
+        /// <inheritdoc cref="IPersistentQueueSession{T}"/>
+        public PersistentQueueSession(IPersistentQueueImpl queue, IFileStream currentStream, int writeBufferSize, int timeoutLimit) : base(queue, currentStream,
+            writeBufferSize, timeoutLimit)
         {
         }
 
+        /// <inheritdoc cref="IPersistentQueueSession{T}"/>
         public new T? Dequeue()
         {
-            throw new NotImplementedException();
+            byte[]? bytes = base.Dequeue();
+            T? obj = SerializationStrategy.Deserialize(bytes);
+            return obj;
+
         }
+
+        /// <inheritdoc cref="IPersistentQueueSession{T}"/>
         public void Enqueue(T data)
         {
-            throw new NotImplementedException();
+            byte[]? bytes = SerializationStrategy.Serialize(data);
+            if (bytes != null)
+            {
+                Enqueue(bytes);
+            }
         }
     }
 }

--- a/src/DiskQueue/PersistentQueue.cs
+++ b/src/DiskQueue/PersistentQueue.cs
@@ -13,7 +13,7 @@ namespace DiskQueue
 	/// <para>If you want to share the store between threads in one process, you may share the Persistent Queue and
 	/// have each thread call `OpenSession` for itself.</para>
 	/// </summary>
-	public sealed class PersistentQueue : IPersistentQueue
+	public class PersistentQueue : IPersistentQueue
 	{
 		private PersistentQueueImpl? _queue;
 
@@ -42,7 +42,7 @@ namespace DiskQueue
 					}
 					catch (PlatformNotSupportedException ex)
 					{
-						Console.WriteLine("Blocked by " + ex.GetType()?.Name + "; " + ex.Message + "\r\n\r\n" + ex.StackTrace);
+						Console.WriteLine("Blocked by " + ex.GetType()?.Name + "; " + ex.Message + Environment.NewLine + Environment.NewLine + ex.StackTrace);
 						throw;
 					}
 					catch
@@ -57,6 +57,11 @@ namespace DiskQueue
 			}
 			throw new TimeoutException("Could not acquire a lock in the time specified");
 		}
+
+		/// <summary>
+		/// THis constructor is only for use by derived classes.
+		/// </summary>
+		protected PersistentQueue() { }
 
 		/// <summary>
 		/// Create or connect to a persistent store at the given storage path.
@@ -195,5 +200,4 @@ namespace DiskQueue
 			public static int FileTimeoutMilliseconds { get; set; } = 10_000;
 		}
 	}
-
 }

--- a/src/DiskQueue/PersistentQueueT.cs
+++ b/src/DiskQueue/PersistentQueueT.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Diagnostics;
+using System.IO;
+using System.Threading;
+using DiskQueue.Implementation;
+
+namespace DiskQueue
+{
+    /// <summary>
+    /// Default persistent queue <see cref="IPersistentQueue"/>
+    /// <para>This queue establishes exclusive use of the storage until it is disposed.</para>
+    /// <para>If you wish to share the store between processes, you should use `PersistentQueue.WaitFor`.</para>
+    /// <para>If you want to share the store between threads in one process, you may share the Persistent Queue and
+    /// have each thread call `OpenSession` for itself.</para>
+    /// </summary>
+    public class PersistentQueue<T> : PersistentQueue, IPersistentQueue<T>
+    {
+        private PersistentQueueImpl<T>? _queue;
+
+        /// <summary>
+        /// Create or connect to a persistent store at the given storage path.
+        /// <para>Throws UnauthorizedAccessException if you do not have read and write permissions.</para>
+        /// <para>Throws InvalidOperationException if another instance is attached to the backing store.</para>
+        /// </summary>
+        public PersistentQueue(string storagePath)
+        {
+            _queue = new PersistentQueueImpl<T>(storagePath);
+        }
+
+        /// <summary>
+        /// Create or connect to a persistent store at the given storage path.
+        /// Uses specific maximum file size (files will be split if they exceed this size).
+        /// <para>Throws UnauthorizedAccessException if you do not have read and write permissions.</para>
+        /// <para>Throws InvalidOperationException if another instance is attached to the backing store.</para>
+        /// If `throwOnConflict` is set to false, data corruption will be silently ignored. Use this only where uptime is more important than data integrity.
+        /// </summary>
+        public PersistentQueue(string storagePath, int maxSize, bool throwOnConflict = true)
+        {
+            _queue = new PersistentQueueImpl<T>(storagePath, maxSize, throwOnConflict);
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <returns></returns>
+        /// <exception cref="Exception"></exception>
+        public new IPersistentQueueSession<T> OpenSession()
+        {
+            if (_queue == null) throw new Exception("This queue has been disposed");
+            return _queue.OpenSession();
+        }
+    }
+}

--- a/src/DiskQueue/PersistentQueueT.cs
+++ b/src/DiskQueue/PersistentQueueT.cs
@@ -1,49 +1,28 @@
 ﻿using System;
-using System.Diagnostics;
-using System.IO;
-using System.Threading;
 using DiskQueue.Implementation;
 
 namespace DiskQueue
 {
-    /// <summary>
-    /// Default persistent queue <see cref="IPersistentQueue"/>
-    /// <para>This queue establishes exclusive use of the storage until it is disposed.</para>
-    /// <para>If you wish to share the store between processes, you should use `PersistentQueue.WaitFor`.</para>
-    /// <para>If you want to share the store between threads in one process, you may share the Persistent Queue and
-    /// have each thread call `OpenSession` for itself.</para>
-    /// </summary>
+    /// <inheritdoc cref="IPersistentQueue{T}" />
     public class PersistentQueue<T> : PersistentQueue, IPersistentQueue<T>
     {
         private PersistentQueueImpl<T>? _queue;
 
-        /// <summary>
-        /// Create or connect to a persistent store at the given storage path.
-        /// <para>Throws UnauthorizedAccessException if you do not have read and write permissions.</para>
-        /// <para>Throws InvalidOperationException if another instance is attached to the backing store.</para>
-        /// </summary>
+        /// <inheritdoc />
         public PersistentQueue(string storagePath)
         {
             _queue = new PersistentQueueImpl<T>(storagePath);
         }
 
-        /// <summary>
-        /// Create or connect to a persistent store at the given storage path.
-        /// Uses specific maximum file size (files will be split if they exceed this size).
-        /// <para>Throws UnauthorizedAccessException if you do not have read and write permissions.</para>
-        /// <para>Throws InvalidOperationException if another instance is attached to the backing store.</para>
-        /// If `throwOnConflict` is set to false, data corruption will be silently ignored. Use this only where uptime is more important than data integrity.
-        /// </summary>
+        /// <inheritdoc />
         public PersistentQueue(string storagePath, int maxSize, bool throwOnConflict = true)
         {
             _queue = new PersistentQueueImpl<T>(storagePath, maxSize, throwOnConflict);
         }
 
         /// <summary>
-        /// 
+        /// Open an read/write session
         /// </summary>
-        /// <returns></returns>
-        /// <exception cref="Exception"></exception>
         public new IPersistentQueueSession<T> OpenSession()
         {
             if (_queue == null) throw new Exception("This queue has been disposed");

--- a/src/DiskQueue/PublicInterfaces/IPersistentQueueImplT.cs
+++ b/src/DiskQueue/PublicInterfaces/IPersistentQueueImplT.cs
@@ -1,13 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace DiskQueue.PublicInterfaces
+﻿namespace DiskQueue
 {
-    /// <summary>
-    /// 
-    /// </summary>
-    /// <typeparam name="T"></typeparam>
+    /// <inheritdoc/>
     public interface IPersistentQueueImpl<T>: IPersistentQueueImpl
     {
     }

--- a/src/DiskQueue/PublicInterfaces/IPersistentQueueImplT.cs
+++ b/src/DiskQueue/PublicInterfaces/IPersistentQueueImplT.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace DiskQueue.PublicInterfaces
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    public interface IPersistentQueueImpl<T>: IPersistentQueueImpl
+    {
+    }
+}

--- a/src/DiskQueue/PublicInterfaces/IPersistentQueueSessionT.cs
+++ b/src/DiskQueue/PublicInterfaces/IPersistentQueueSessionT.cs
@@ -1,0 +1,22 @@
+﻿using System;
+
+namespace DiskQueue
+{
+    /// <summary>
+    /// Queue session (exclusive use of the queue to add or remove items)
+    /// The queue session should be wrapped in a `using`, as it must be disposed.
+    /// If you are sharing access, you should hold the queue session for as little time as possible.
+    /// </summary>
+    public interface IPersistentQueueSession<T> : IPersistentQueueSession
+    {
+        /// <summary>
+        /// Queue data for a later decode. Data is written on `Flush()`
+        /// </summary>
+        void Enqueue(T data);
+
+        /// <summary>
+        /// Try to pull data from the queue. Data is removed from the queue on `Flush()`
+        /// </summary>
+        new T? Dequeue();
+    }
+}

--- a/src/DiskQueue/PublicInterfaces/IPersistentQueueSessionT.cs
+++ b/src/DiskQueue/PublicInterfaces/IPersistentQueueSessionT.cs
@@ -1,12 +1,6 @@
-﻿using System;
-
-namespace DiskQueue
+﻿namespace DiskQueue
 {
-    /// <summary>
-    /// Queue session (exclusive use of the queue to add or remove items)
-    /// The queue session should be wrapped in a `using`, as it must be disposed.
-    /// If you are sharing access, you should hold the queue session for as little time as possible.
-    /// </summary>
+    /// <inheritdoc/>
     public interface IPersistentQueueSession<T> : IPersistentQueueSession
     {
         /// <summary>

--- a/src/DiskQueue/PublicInterfaces/ISerializationStrategy.cs
+++ b/src/DiskQueue/PublicInterfaces/ISerializationStrategy.cs
@@ -1,0 +1,23 @@
+﻿namespace DiskQueue
+{
+    /// <summary>
+    /// This class performs basic binary serialization from objects of Type T to byte arrays suitable for use in DiskQueue sessions.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    public interface ISerializationStrategy<T>
+    {
+        /// <summary>
+        /// Deserializes byte array into object reference of type T.
+        /// </summary>
+        /// <param name="bytes">Byte array to deserialize</param>
+        /// <returns>Object instance of type T.</returns>
+        public T? Deserialize(byte[]? bytes);
+
+        /// <summary>
+        /// Serialized passed object into byte array suitable for queuing into a <see cref="PersistentQueue{T}"/>.
+        /// </summary>
+        /// <param name="obj">Object to serialize. Class must be decorated with Serializable annotation.</param>
+        /// <returns>Byte array.</returns>
+        public byte[]? Serialize(T? obj);
+    }
+}

--- a/src/DiskQueue/PublicInterfaces/Interface1.cs
+++ b/src/DiskQueue/PublicInterfaces/Interface1.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace DiskQueue.PublicInterfaces
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    public interface ISerializationStrategy<T>
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="bytes"></param>
+        /// <returns></returns>
+        public T Deserialize(byte[] bytes);
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="obj"></param>
+        /// <returns></returns>
+        public byte[] Serialize(T obj);
+    }
+}


### PR DESCRIPTION
DiskQueue is a great library (really!). It is, however, a little obtuse to use, as byte arrays are not things we normally use in our day-to-day work. 

I decided to create a strongly typed implementation using generics that can queue and dequeue objects directly. This was surprisingly less difficult than I thought it would be. 

I used the built-in .NET serialization to convert between objects and byte arrays, which seems to work well enough ( although it does mean that the class being serialized must be decorated with the [Serializable] annotation).

 Since I don't claim to be an expert on all things serialization, if you would like to use something else (e.g. Json.NET), or want to more granularly control the serialization  (e.g. excluding certain properties), you are free to create and inject your own ISerializationStrategy class.

If this pull request is accepted, I will update the documentation on the README.MD with some examples of using the strongly-typed classes.