### PR TITLE
Expose SerializationStrategy

### DIFF
--- a/src/DiskQueue/Implementation/PersistentQueueSessionT.cs
+++ b/src/DiskQueue/Implementation/PersistentQueueSessionT.cs
@@ -3,10 +3,7 @@
     /// <inheritdoc cref="IPersistentQueueSession{T}"/>
     public class PersistentQueueSession<T> : PersistentQueueSession, IPersistentQueueSession<T>
     {
-        /// <summary>
-        /// This class performs the serialization of the object to be queued into a byte array suitable for queueing.
-        /// It defaults to <see cref="DefaultSerializationStrategy{T}"/>, but you are free to implement your own and inject it in.
-        /// </summary>
+        /// <inheritdoc cref="IPersistentQueueSession{T}"/>
         public ISerializationStrategy<T> SerializationStrategy { get; set; } = new DefaultSerializationStrategy<T>();
 
         /// <inheritdoc cref="IPersistentQueueSession{T}"/>

--- a/src/DiskQueue/PublicInterfaces/IPersistentQueueSessionT.cs
+++ b/src/DiskQueue/PublicInterfaces/IPersistentQueueSessionT.cs
@@ -1,4 +1,6 @@
-﻿namespace DiskQueue
+﻿using DiskQueue.Implementation;
+
+namespace DiskQueue
 {
     /// <inheritdoc/>
     public interface IPersistentQueueSession<T> : IPersistentQueueSession
@@ -12,5 +14,11 @@
         /// Try to pull data from the queue. Data is removed from the queue on `Flush()`
         /// </summary>
         new T? Dequeue();
+
+        /// <summary>
+        /// This class performs the serialization of the object to be queued into a byte array suitable for queueing.
+        /// It defaults to <see cref="DefaultSerializationStrategy{T}"/>, but you are free to implement your own and inject it in.
+        /// </summary>
+        ISerializationStrategy<T> SerializationStrategy { get; set; }
     }
 }


### PR DESCRIPTION
Just noticed that the PersistentQueueSession<T> SerializationStategy was not added to the IPersistentQueueSession<T> Interface, making it difficult to inject a new strategy without cumbersome casting.