### PR TITLE
Add support to validate running process is actual locking process

### DIFF
--- a/src/DiskQueue.Tests/FileLockedQueueTest.cs
+++ b/src/DiskQueue.Tests/FileLockedQueueTest.cs
@@ -1,0 +1,104 @@
+﻿using DiskQueue.Implementation;
+using NUnit.Framework;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DiskQueue.Tests
+{
+    [TestFixture]
+    public class FileLockedQueueTest
+    {
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
+        private Process _otherProcess;
+        private Process _currentProcess;
+#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
+        private int _currentThread;
+
+        [OneTimeSetUp]
+        public void OneTimeSetUp() 
+        {
+            _currentProcess = Process.GetCurrentProcess();
+            _currentThread = Thread.CurrentThread.ManagedThreadId;
+            _otherProcess = Process.GetProcesses().Where(x => x.Id != 0 && x.Id != _currentProcess.Id).First();
+        }
+
+        [Test]
+        public void FileIsLockedAfterPowerFailure_QueueObtainsLock()
+        {
+            //ARRANGE
+            var queueName = GetQueueName();
+            WriteLockFile(queueName, _otherProcess.Id, _currentThread, _otherProcess.StartTime.AddSeconds(1));
+
+            //ACT
+            using var queue = new PersistentQueue<string>(queueName);
+        }
+
+        [Test]
+        public void FileIsLockedByCurentProcessButWrongThread_ThrowsException()
+        {
+            //ARRANGE
+            var queueName = GetQueueName();
+            WriteLockFile(queueName, _currentProcess.Id, 555, _currentProcess.StartTime);
+
+            try
+            {
+                //ACT
+                using var queue = new PersistentQueue<string>(queueName);
+            }
+            catch(InvalidOperationException ex)
+            {
+                //ASSERT
+                Assert.AreEqual("This queue is locked by another thread in this process. Thread id = 555", ex.InnerException.Message);
+                Assert.Pass();
+            }
+            Assert.Fail();
+        }
+
+        [Test]
+        public void FileIsLockedByOtherRunningProcess_ThrowsException()
+        {
+            //ARRANGE
+            var queueName = GetQueueName();
+            WriteLockFile(queueName, _otherProcess.Id, 555, _otherProcess.StartTime);
+
+            try
+            {
+                //ACT
+                using var queue = new PersistentQueue<string>(queueName);
+            }
+            catch (InvalidOperationException ex)
+            {
+                //ASSERT
+                Assert.AreEqual($"This queue is locked by another running process. Process id = {_otherProcess.Id}", ex.InnerException.Message);
+                Assert.Pass();
+            }
+            Assert.Fail();
+        }
+
+        private static string GetQueueName()
+        {
+            var valueToTest = "a string";
+            var hash = valueToTest.GetHashCode().ToString("X8");
+            return $"./LockQueueTests_{hash}";
+        }
+
+        private void WriteLockFile(string queueName, int processId, int threadId, DateTime startTime)
+        {
+            var lockData = new LockFileData
+            {
+                ProcessId = processId,
+                ThreadId = threadId,
+                ProcessStart = ((DateTimeOffset)startTime).ToUnixTimeMilliseconds(),
+            };
+            Directory.CreateDirectory(queueName);
+            File.WriteAllBytes($@"{queueName}\lock", MarshallHelper.Serialize(lockData));
+        }
+    }
+}

--- a/src/DiskQueue.Tests/LockFileDataSerializationTest.cs
+++ b/src/DiskQueue.Tests/LockFileDataSerializationTest.cs
@@ -1,0 +1,63 @@
+﻿using DiskQueue.Implementation;
+using NUnit.Framework;
+
+namespace DiskQueue.Tests
+{
+    [TestFixture]
+    internal class LockFileDataSerializationTest
+    {
+        [Test]
+        public void ConvertToBytes_ExpectedOrderIsObtained()
+        {
+            var expected = new byte[]
+            {
+                8, 1, 0, 0,
+                16, 2, 0, 0,
+                32, 4, 0, 0, 0, 0, 0, 0
+            };
+
+            var data = new LockFileData();
+            data.ProcessId = 8 + 256 * 1;
+            data.ThreadId = 16 + 256 * 2;
+            data.ProcessStart = 32 + 256 * 4;
+
+            var actual = MarshallHelper.Serialize(data);
+            for (var i = 0; i < expected.Length && i < actual.Length; i++)
+            {
+                Assert.AreEqual(expected[i], actual[i]);
+            }
+        }
+
+        [Test]
+        public void ConvertFromBytes_MissingProcessStart_DeserializesCorrectly()
+        {
+            var input = new byte[]
+            {
+                8, 1, 0, 0,
+                16, 2, 0, 0,
+                //32, 4, 0, 0, 0, 0, 0, 0 // no ProcessStart bytes
+            };
+
+            var actual = MarshallHelper.Deserialize<LockFileData>(input);
+            Assert.AreEqual(8 + 256 * 1, actual.ProcessId);
+            Assert.AreEqual(16 + 256 * 2, actual.ThreadId);
+            Assert.AreEqual(0, actual.ProcessStart);
+        }
+
+        [Test]
+        public void ConvertFromBytes_CompleteData_DeserializesCorrectly()
+        {
+            var input = new byte[]
+            {
+                8, 1, 0, 0,
+                16, 2, 0, 0,
+                32, 4, 0, 0, 0, 0, 0, 0
+            };
+
+            var actual = MarshallHelper.Deserialize<LockFileData>(input);
+            Assert.AreEqual(8 + 256 * 1, actual.ProcessId);
+            Assert.AreEqual(16 + 256 * 2, actual.ThreadId);
+            Assert.AreEqual(32 + 256 * 4, actual.ProcessStart);
+        }
+    }
+}

--- a/src/DiskQueue/Implementation/LockFileData.cs
+++ b/src/DiskQueue/Implementation/LockFileData.cs
@@ -1,0 +1,26 @@
+﻿using System.Runtime.InteropServices;
+
+namespace DiskQueue.Implementation
+{
+    /// <summary>
+    /// struct file containing the data related to the lock file
+    /// order of fields matters, please use correct attributes if you want to rearange them
+    /// </summary>
+    public struct LockFileData
+    {
+        /// <summary>
+        /// PID of the locking process
+        /// </summary>
+        public int ProcessId;
+
+        /// <summary>
+        /// Thread ID from the locking process
+        /// </summary>
+        public int ThreadId;
+
+        /// <summary>
+        /// Process start time represented as unix offset in milliseconds
+        /// </summary>
+        public long ProcessStart;
+    }
+}

--- a/src/DiskQueue/Implementation/MarshallHelper.cs
+++ b/src/DiskQueue/Implementation/MarshallHelper.cs
@@ -1,0 +1,73 @@
+﻿using System.Runtime.InteropServices;
+using System;
+
+namespace DiskQueue.Implementation
+{
+    /// <summary>
+    /// Helper class used to help with serializing to bytes
+    /// </summary>
+    public class MarshallHelper
+    {
+        /// <summary>
+        /// Serializes a structure to a byte array.
+        /// </summary>
+        /// <param name="value">The structure to serialize to a byte array.</param>
+        /// <returns>The object serialized to a byte array, ready to write to a stream.</returns>
+        public static byte[] Serialize<T>(T value)
+        {
+            // Get the size of our structure in bytes
+            var structSize = Marshal.SizeOf(value);
+
+            // This will contain the result, and be returned
+            var bytes = new byte[structSize];
+
+            // Allocate some unmanaged memory for our structure
+            var pointer = IntPtr.Zero;
+
+            try
+            {
+                pointer = Marshal.AllocHGlobal(structSize);
+
+                // Write the structure to the unmanaged memory
+                Marshal.StructureToPtr(value, pointer, false);
+
+                // Copy the resulting bytes from unmanaged memory to our result array
+                Marshal.Copy(pointer, bytes, 0, structSize);
+
+                return bytes;
+            }
+            finally
+            {
+                if (pointer != IntPtr.Zero)
+                {
+                    // Free up our unmanaged memory
+                    Marshal.FreeHGlobal(pointer);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Deserializes a structure from a byte array.
+        /// </summary>
+        /// <param name="data">The object binary data to deserialize from.</param>
+        /// <returns>The deserialized structure.</returns>
+        public static T Deserialize<T>(byte[] data)
+        {
+            var pinnedPacket = new GCHandle();
+
+            T result;
+
+            try
+            {
+                pinnedPacket = GCHandle.Alloc(data, GCHandleType.Pinned);
+                result = (T)Marshal.PtrToStructure(pinnedPacket.AddrOfPinnedObject(), typeof(T));
+            }
+            finally
+            {
+                pinnedPacket.Free();
+            }
+
+            return result;
+        }
+    }
+}


### PR DESCRIPTION
Added Process.StartTime to the file as unix offset in ms.
Changed serialization implementation to use Marshall and Struct.
The StartTime is used to ensure that the PID in the lock file points to the original locking process and not another process that received the same ID.