### PR TITLE
Changed version in the the csproj file from 1.6.7 to 1.7.1 to match nuget package

### DIFF
--- a/src/DiskQueue/DiskQueue.csproj
+++ b/src/DiskQueue/DiskQueue.csproj
@@ -4,9 +4,9 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>9</LangVersion>
     <Nullable>enable</Nullable>
-    <PackageVersion>1.6.7</PackageVersion>
-    <AssemblyVersion>1.6.7.0</AssemblyVersion>
-    <FileVersion>1.6.7.0</FileVersion>
+    <PackageVersion>1.7.1</PackageVersion>
+    <AssemblyVersion>1.7.1.0</AssemblyVersion>
+    <FileVersion>1.7.1.0</FileVersion>
     <ApplicationVersion>1.3.2</ApplicationVersion>
     <Version>1.3.2</Version>
     <Copyright>2013-2023 Iain Ballard</Copyright>


### PR DESCRIPTION
I changed the package version, assemblyversion, and fileversion in the DiskQueue.csproj file to match the current version number shown in nuget.
This was done to support Iain's statement that the master branch is up to date with the nuget package. https://github.com/i-e-b/DiskQueue/issues/35#issuecomment-2766180536
The old version number still shows up in Visual Studio when viewing the definition of a method, so I think this change will correct that.
![dqdefinitionview](https://github.com/user-attachments/assets/2006aaaa-d7f6-410b-86df-07f9cf164476)
